### PR TITLE
added comment about integration in PrimeFaces

### DIFF
--- a/src/main/java/org/omnifaces/optimusfaces/renderer/ExtendedDataTableRenderer.java
+++ b/src/main/java/org/omnifaces/optimusfaces/renderer/ExtendedDataTableRenderer.java
@@ -25,7 +25,8 @@ import org.primefaces.component.datatable.DataTableRenderer;
  * <p>
  * This extended data table renderer is already automatically registered via our <code>faces-config.xml</code>. This
  * will prevent hackers from being able to exceed the <code>rows</code> attribute of the <code>&lt;p:dataTable&gt;</code>
- * which could cause a heavy load on large datasets.
+ * which could cause a heavy load on large datasets. PrimeFaces integrates this code as of version 6.3.
+ * @see <a href="https://github.com/primefaces/primefaces/issues/3519">PrimeFaces #3519</a>
  */
 public class ExtendedDataTableRenderer extends DataTableRenderer {
 


### PR DESCRIPTION
- integrated in PrimeFaces 6.3, see https://github.com/primefaces/primefaces/issues/3519
- using optimusfaces with PrimeFaces >= 6.3 will result in checking the `rows` parameter twice, can we check for the PrimeFaces version in use?
- you'd go better with the PrimeFaces integration since other `DataRenderer` implementations are considered as well