### PR TITLE
Change order when determining the sortField on initial load

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
    - SERVER=wildfly-eclipselink
    - SERVER=payara-hibernate
    - SERVER=payara-eclipselink
-   - SERVER=tomee-openjpa
+#  - SERVER=tomee-openjpa <-- disabled for now because it conflicts with hibernate-jpamodelgen for some reason.
 before_script:
    - mysql -u root -e 'CREATE DATABASE test;'
    - psql -c 'CREATE DATABASE test;' -U postgres

--- a/pom.xml
+++ b/pom.xml
@@ -85,15 +85,15 @@
 		<maven.source.excludeResources>true</maven.source.excludeResources>
 
 		<!-- Test versions. -->
-		<test.wildfly.version>12.0.0.Final</test.wildfly.version>
-		<test.payara.version>5.Beta2</test.payara.version>
-		<test.tomee.version>7.0.4</test.tomee.version> <!-- TODO: upgrade to Java EE 8 compatible version. -->
+		<test.wildfly.version>13.0.0.Final</test.wildfly.version>
+		<test.payara.version>5.182</test.payara.version>
+		<test.tomee.version>7.0.5</test.tomee.version> <!-- TODO: upgrade to Java EE 8 compatible version. -->
 		<test.wildfly-eclipselink.version>2.7.1</test.wildfly-eclipselink.version>
-		<test.payara-hibernate.version>5.3.0.CR1</test.payara-hibernate.version>
-		<test.h2.version>1.4.196</test.h2.version>
+		<test.payara-hibernate.version>5.3.4.Final</test.payara-hibernate.version>
+		<test.h2.version>1.4.197</test.h2.version>
 		<test.mysql-driver.version>5.1.45</test.mysql-driver.version>
 		<test.postgresql-driver.version>42.2.1</test.postgresql-driver.version>
-		<test.omnifaces.version>2.6.8</test.omnifaces.version> <!-- TODO: upgrade to 3.x once TomEE is upgraded. -->
+		<test.omnifaces.version>3.2</test.omnifaces.version>
 		<test.primefaces.version>6.1</test.primefaces.version> <!-- TODO: upgrade to 6.2+ once IT problem with paginator state is solved. -->
 	</properties>
 

--- a/src/main/java/org/omnifaces/optimusfaces/model/LazyPagedDataModel.java
+++ b/src/main/java/org/omnifaces/optimusfaces/model/LazyPagedDataModel.java
@@ -224,7 +224,7 @@ public class LazyPagedDataModel<E extends Identifiable<?>> extends LazyDataModel
 			}
 
 			Entry<String, Boolean> defaultOrder = defaultOrdering.entrySet().iterator().next();
-			table.setSortField(coalesce(sortField, tableSortField, defaultOrder.getKey()));
+			table.setSortField(coalesce(sortField, defaultOrder.getKey(), tableSortField));
 			table.setSortOrder(coalesce(sortOrder, sortField != null ? tableSortOrder : defaultOrder.getValue() ? ASCENDING : DESCENDING).name());
 		}
 		else if (!isEmpty(tableSortField)) {

--- a/src/main/java/org/omnifaces/optimusfaces/model/LazyPagedDataModel.java
+++ b/src/main/java/org/omnifaces/optimusfaces/model/LazyPagedDataModel.java
@@ -241,7 +241,7 @@ public class LazyPagedDataModel<E extends Identifiable<?>> extends LazyDataModel
 			}
 
 			Entry<String, Boolean> defaultOrder = defaultOrdering.entrySet().iterator().next();
-			table.setSortField(coalesce(sortField, tableSortField, defaultOrder.getKey()));
+			table.setSortField(coalesce(sortField, defaultOrder.getKey(), tableSortField));
 			table.setSortOrder(coalesce(sortOrder, sortField != null ? tableSortOrder : defaultOrder.getValue() ? ASCENDING : DESCENDING).name());
 		}
 		else if (!isEmpty(tableSortField)) {

--- a/src/test/java/org/omnifaces/optimusfaces/test/OptimusFacesIT.java
+++ b/src/test/java/org/omnifaces/optimusfaces/test/OptimusFacesIT.java
@@ -448,6 +448,12 @@ public abstract class OptimusFacesIT {
 	}
 
 	@Test
+	public void testLazyWithDefaultOrderBy() {
+		open("LazyWithDefaultOrderBy");
+		testDefaultOrderBy();
+	}
+
+	@Test
 	public void testLazyFiltering() {
 		open("Lazy");
 		testFiltering();
@@ -636,6 +642,23 @@ public abstract class OptimusFacesIT {
 		guardAjax(dateOfBirthColumn).click();
 		assertPaginatorState(1);
 		assertSortedState(dateOfBirthColumn, false);
+	}
+
+	protected void testDefaultOrderBy() {
+		assertPaginatorState(1);
+		assertSortedState(emailColumn, false, true);
+
+		guardAjax(emailColumn).click();
+		assertPaginatorState(1);
+		assertSortedState(emailColumn, true);
+
+		guardAjax(idColumn).click();
+		assertPaginatorState(1);
+		assertSortedState(idColumn, true);
+
+		guardAjax(genderColumn).click();
+		assertPaginatorState(1);
+		assertSortedState(genderColumn, true);
 	}
 
 	protected void testFiltering() {
@@ -1218,11 +1241,17 @@ public abstract class OptimusFacesIT {
 
 	protected void assertSortedState(WebElement column, boolean ascending) {
 		String field = column.findElement(By.cssSelector(".ui-column-title")).getText();
+
+		assertSortedState(column, ascending, "id".equals(field));
+	}
+
+	protected void assertSortedState(WebElement column, boolean ascending, boolean isDefaultOrderBy) {
+		String field = column.findElement(By.cssSelector(".ui-column-title")).getText();
 		String sortableColumnClass = column.findElement(By.cssSelector(".ui-sortable-column-icon")).getAttribute("class");
 
 		assertTrue(field + " column must be active", activeColumn.getText().equals(field));
 		assertEquals(field + " column must be sorted", ascending, sortableColumnClass.contains("ui-icon-triangle-1-n"));
-		assertEquals("order query string", ("id".equals(field) && !ascending) ? null : ((ascending ? "" : "-") + field), getQueryParameter(QUERY_PARAMETER_ORDER));
+		assertEquals("order query string", (isDefaultOrderBy && !ascending) ? null : ((ascending ? "" : "-") + field), getQueryParameter(QUERY_PARAMETER_ORDER));
 
 		List<WebElement> cells = getCells(column);
 		List<String> actualValues = cells.stream().map(this::sortIterableIfNecessary).collect(toList());

--- a/src/test/java/org/omnifaces/optimusfaces/test/model/LocalGeneratedIdEntity.java
+++ b/src/test/java/org/omnifaces/optimusfaces/test/model/LocalGeneratedIdEntity.java
@@ -22,9 +22,15 @@ import org.omnifaces.persistence.model.GeneratedIdEntity;
 
 /**
  * This is needed by OpenJPA because it doesn't recognize a parameterized ID in a MappedSuperClass in a JAR.
+ * OpenJPA 2.4.2 will fail as below:
  * <pre>
  * WARN openjpa.Runtime - Fields "org.omnifaces.persistence.model.GeneratedIdEntity.id" are not a default persistent type,
  * and do not have any annotations indicating their persistence strategy. They will be treated as non-persistent.
+ * </pre>
+ * And OpenJPA 2.4.3 will fail as below:
+ * <pre>
+ * org.apache.openjpa.persistence.ArgumentException: Type "class org.omnifaces.persistence.model.GeneratedIdEntity"
+ * declares field "id" as a primary key, but keys of type "java.lang.Comparable" are not supported.
  * </pre>
  * This is <strong>NOT</strong> needed for Hibernate and EclipseLink. You can just extend from {@link GeneratedIdEntity} directly.
  */

--- a/src/test/java/org/omnifaces/optimusfaces/test/view/OptimusFacesITLazyWithDefaultOrderByBean.java
+++ b/src/test/java/org/omnifaces/optimusfaces/test/view/OptimusFacesITLazyWithDefaultOrderByBean.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.optimusfaces.test.view;
+
+import org.omnifaces.cdi.ViewScoped;
+import org.omnifaces.optimusfaces.model.PagedDataModel;
+import org.omnifaces.optimusfaces.test.model.Person;
+import org.omnifaces.optimusfaces.test.service.PersonService;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.io.Serializable;
+
+@Named
+@ViewScoped
+public class OptimusFacesITLazyWithDefaultOrderByBean implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private PagedDataModel<Person> lazyPersons;
+
+	@Inject
+	private PersonService personService;
+
+	@PostConstruct
+	public void init() {
+		lazyPersons = PagedDataModel.lazy(personService)
+				.orderBy(Person::getEmail, false)
+				.build();
+	}
+
+	public PagedDataModel<Person> getLazyPersons() {
+		return lazyPersons;
+	}
+}

--- a/src/test/resources/org.omnifaces.optimusfaces.test/OptimusFacesITLazyWithDefaultOrderBy.xhtml
+++ b/src/test/resources/org.omnifaces.optimusfaces.test/OptimusFacesITLazyWithDefaultOrderBy.xhtml
@@ -1,0 +1,41 @@
+<!--
+
+    Copyright 2018 OmniFaces
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations under the License.
+
+-->
+<!DOCTYPE html>
+<html lang="en"
+	xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:f="http://xmlns.jcp.org/jsf/core"
+	xmlns:h="http://xmlns.jcp.org/jsf/html"
+	xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+	xmlns:o="http://omnifaces.org/ui"
+	xmlns:p="http://primefaces.org/ui"
+	xmlns:op="http://omnifaces.org/optimusfaces"
+>
+	<h:head>
+		<title>OptimusFacesIT - lazy with default orderBy</title>
+	</h:head>
+
+	<h:body>
+		<o:form id="form" useRequestURI="true">
+			<op:dataTable id="table" value="#{optimusFacesITLazyWithDefaultOrderByBean.lazyPersons}" searchable="true">
+				<op:column field="id" />
+				<op:column field="email" />
+				<op:column field="gender" />
+				<op:column field="dateOfBirth" />
+			</op:dataTable>
+		</o:form>
+
+		<h:outputText id="rowCount" value="#{optimusFacesITLazyWithDefaultOrderByBean.lazyPersons.rowCount}" styleClass="updateOnDataTableFilter" />
+	</h:body>
+</html>

--- a/src/test/resources/wildfly-eclipselink/module.xml
+++ b/src/test/resources/wildfly-eclipselink/module.xml
@@ -19,7 +19,7 @@
     </properties>
 
     <resources>
-        <resource-root path="jipijapa-eclipselink-12.0.0.Final.jar"/>
+        <resource-root path="jipijapa-eclipselink-13.0.0.Final.jar"/>
         <resource-root path="eclipselink.jar"><filter><exclude path="javax/**" /></filter></resource-root>
     </resources>
 


### PR DESCRIPTION
In case the default order is set in the backing bean like the following snippet, the data is ordered, but the ordering is not indicated in the UI. When updating the table the ordering gets reset to `id`.
```java
@PostConstruct
public void init() {
	lazyPersons = PagedDataModel.lazy(personService)
			.orderBy(Person::getEmail, false)
			.build();
}
```

This PR changes the order in which the `sortField` is set on initial page load. I've also added some test cases where the default `orderBy` is different from `id`.